### PR TITLE
Fix unused result warning

### DIFF
--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -227,7 +227,7 @@ fn gen_enumflags(ident: &Ident, item: &MacroInput, data: &Vec<Variant>) -> Token
                         _ => None
                     }
                 }).collect();
-                fmt.write_str(&format!("0b{:b}, Flags::", self.0));
+                fmt.write_str(&format!("0b{:b}, Flags::", self.0))?;
                 fmt.debug_list().entries(v.iter()).finish()
             }
         }


### PR DESCRIPTION
Derivation of `EnumFlags` gave an `unused_must_use` warning.
> warning: unused result which must be used, #[warn(unused_must_use)] on by default
>#[derive(__EnumFlags__, Copy, Clone, Debug)]
