### PR TITLE
Add `field_val` method

### DIFF
--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -192,6 +192,10 @@ fn gen_enumflags(ident: &Ident, item: &MacroInput, data: &Vec<Variant>) -> Token
                 let new_val = *self ^ other;
                 *self = new_val;
             }
+
+            fn field_val(self, other: Self) -> Self::Type {
+                (self & other).bits() >> other.bits().trailing_zeros()
+            }
         }
 
         impl Into<#ty> for #inner_name{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub trait InnerBitFlags: BitOr<Self> + cmp::PartialEq + cmp::Eq
     fn insert(&mut self, other: Self);
     fn remove(&mut self, other: Self);
     fn toggle(&mut self, other: Self);
+    fn field_val(self, other: Self) -> Self::Type;
 }
 
 #[derive(Eq, Copy, Clone)]
@@ -114,6 +115,10 @@ impl<T> BitFlags<T>
 
     pub fn remove(&mut self, other: Self) {
         T::Size::remove(&mut self.val, other.val);
+    }
+
+    pub fn field_val(self, other: T::Size) -> <T::Size as InnerBitFlags>::Type {
+        T::Size::field_val(self.val, other)
     }
 }
 


### PR DESCRIPTION
**WIP!** I came across the need of accessing bit ranges, and I thought it could be a good idea. What's your opinion? For example:

# The idea
```rust
#[macro_use]
extern crate enumflags_derive;
extern crate enumflags;

#[derive(EnumFlags)]
#[repr(u8)]
enum Flag {
    FlagA = 0b00000001,
    FlagB = 0b00000010,
    FlagC = 0b00000100,
    Field = 0b11111000
}

fn main() {
    let mask = Flag::Field;
    let val: BitFlags<Flag> = BitFlags::from_bits_truncate(0b01010001);
    let result = val.field_val(mask);

    // 0b00001010
    println!("{:08b}", result);
}
```

# Drawbacks
It has for me one drawback (at least with the current implementation). If bits are scattered, they aren't joined. Instead, separation between them is kept.

# Other ideas
Maybe adding a setter is a good idea, but I think it's a bit out of the scope of this project.

I opened the PR just for discussion, to have an implementation to back the idea. Neither the name or the implementation are definitive.