### PR TITLE
Remove dependency on num module

### DIFF
--- a/enumflags/Cargo.toml
+++ b/enumflags/Cargo.toml
@@ -9,9 +9,6 @@ readme = "../README.md"
 keywords = ["enum", "bitflag", "flag", "bitflags"]
 documentation = "https://docs.rs/enumflags"
 
-[dependencies]
-num = "0.1.41"
-
 [features]
 default = []
 nostd = []

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -1,14 +1,12 @@
 #[cfg(feature = "nostd")]
 extern crate core as std;
-extern crate num;
 
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 use std::cmp::PartialOrd;
 use std::fmt::{self, Formatter};
-use num::{Num, Zero};
 
 pub trait BitFlagNum
-    : Num
+    : Default
     + BitOr<Self, Output = Self>
     + BitAnd<Self, Output = Self>
     + BitXor<Self, Output = Self>
@@ -73,7 +71,7 @@ where
 {
     /// Create an empty BitFlags. Empty means `0`.
     pub fn empty() -> Self {
-        unsafe { BitFlags::new(T::Type::zero()) }
+        unsafe { BitFlags::new(T::Type::default()) }
     }
 
     /// Sets all flags.


### PR DESCRIPTION
The num module drags in a bunch of other submodules. However, the
dependency on num is rather superficial. It is only required to ensure a
zero value for the current type, which is always a number primitive.
However, the existing number primitive types already implement the Default
trait whose default() method returns zero. Switching to this method removes
the dependency on the num module altogether.

Although it is logically possible that default() might be changed in the
future to return a non-zero value, it will never happen in reality. This is
a reasonable trade-off to reduce the number of dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/enumflags/9)
<!-- Reviewable:end -->
