### PR TITLE
Add Bit(Or|And|Xor)Assign to BitFlags

### DIFF
--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -186,6 +186,35 @@ where
     }
 }
 
+impl<T, B> std::ops::BitOrAssign<B> for BitFlags<T>
+where
+    T: RawBitFlags,
+    B: Into<BitFlags<T>>,
+{
+    fn bitor_assign(&mut self, other: B) {
+        *self = *self | other;
+    }
+}
+
+impl<T, B> std::ops::BitAndAssign<B> for BitFlags<T>
+where
+    T: RawBitFlags,
+    B: Into<BitFlags<T>>,
+{
+    fn bitand_assign(&mut self, other: B) {
+        *self = *self & other;
+    }
+}
+impl<T, B> std::ops::BitXorAssign<B> for BitFlags<T>
+where
+    T: RawBitFlags,
+    B: Into<BitFlags<T>>,
+{
+    fn bitxor_assign(&mut self, other: B) {
+        *self = *self ^ other;
+    }
+}
+
 impl<T> std::ops::Not for BitFlags<T>
 where
     T: RawBitFlags,

--- a/test_suite/tests/bitflag_tests.rs
+++ b/test_suite/tests/bitflag_tests.rs
@@ -74,3 +74,18 @@ fn test_foo() {
     }
     assert_eq!((Test::A ^ Test::B), Test::A | Test::B);
 }
+
+#[test]
+fn assign_ops() {
+    let mut x = Test::A | Test::B;
+    x |= Test::C;
+    assert_eq!(x, Test::A | Test::B | Test::C);
+
+    let mut x = Test::A | Test::B;
+    x &= Test::B | Test::C;
+    assert_eq!(x, Test::B);
+
+    let mut x = Test::A | Test::B;
+    x ^= Test::B | Test::C;
+    assert_eq!(x, Test::A | Test::C);
+}


### PR DESCRIPTION
Since it already has Bit(Or|And|Xor), I didn’t see any reason why it shouldn’t have the assigning version of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/enumflags/11)
<!-- Reviewable:end -->
